### PR TITLE
解决在Windows中开发时，运行报错

### DIFF
--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/smtp"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -47,7 +46,7 @@ func GetCurrentTime() time.Time {
 }
 
 func GetCurrentDirectory() string {
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	dir, err := os.Getwd()
 	if err != nil {
 		seelog.Critical(err)
 	}


### PR DESCRIPTION
解决在Windows中开发时报错panic: html/template: pattern matches no files: `C:\Users\ZekeRuan\AppData\Local\JetBrains\GoLand2024.3\tmp\GoLand\views\**\*`